### PR TITLE
Fixed Typo and Removed Vue Component Methods' Fat Arrow Syntax

### DIFF
--- a/src/cancel-button.vue
+++ b/src/cancel-button.vue
@@ -58,7 +58,7 @@
     },
 
     methods: {
-      _onStatusChange: (id, oldStatus, newStatus) => {
+      _onStatusChange (id, oldStatus, newStatus) {
         if (id === this.id && !this._unmounted) {
           if (!isCancelable(newStatus) && this.state.cancelable) {
             this.$set(this.state, 'cancelable', false)
@@ -70,9 +70,11 @@
         }
       },
 
-      _onClick: () => this.uploader.methods.cancel(this.id),
+      _onClick () {
+        this.uploader.methods.cancel(this.id)
+      },
 
-      _unregisterStatusChangeHandler: () => {
+      _unregisterStatusChangeHandler () {
         this.uploader.off('statusChange', this._onStatusChange)
       }
     }

--- a/src/delete-button.vue
+++ b/src/delete-button.vue
@@ -54,7 +54,7 @@
     },
 
     methods: {
-      _onStatusChange: (id, oldStatus, newStatus) => {
+      _onStatusChange (id, oldStatus, newStatus) {
         if (id === this.id && !this._unmounted) {
           if (!isDeletable(newStatus) && newStatus !== 'deleting' && this.state.deletable) {
             !this._unmounted && this.$set(this.state, 'deletable', false)
@@ -69,9 +69,11 @@
         }
       },
 
-      _onClick: () => this.uploader.methods.deleteFile(this.props.id),
+      _onClick () {
+        this.uploader.methods.deleteFile(this.props.id)
+      },
 
-      _unregisterStatusChangeHandler: () => {
+      _unregisterStatusChangeHandler () {
         this.uploader.off('statusChange', this._onStatusChange)
       }
     }

--- a/src/dropzone.vue
+++ b/src/dropzone.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fine-uploader-dropzone-container" ref="dropZone">
-      <slot ref="emement"></slot>
+      <slot ref="element"></slot>
   </div>
 </template>
 

--- a/src/filename.vue
+++ b/src/filename.vue
@@ -32,9 +32,11 @@
     },
 
     methods: {
-      shouldComponentUpdate: (nextProps, nextState) => nextState.filename !== this.state.filename,
+      shouldComponentUpdate (nextProps, nextState) {
+        return nextState.filename !== this.state.filename
+      },
 
-      _interceptSetName: () => {
+      _interceptSetName () {
         const oldSetName = this.uploader.methods.setName
 
         this.uploader.methods.setName = (id, newName) => {


### PR DESCRIPTION
Vue component methods are intended to be bound to the instance of the component when called, using the fat arrow function syntax causes `this` to be undefined after the ES6 is compiled back down to plain old JS.

Also fixed a typo: `emement` to `element`.