### PR TITLE
Implemented <file-input/>

### DIFF
--- a/src/file-input.vue
+++ b/src/file-input.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="vue-fine-uploader-file-input">
-    <label :for="inputID">
+    <label>
       <slot>Upload File</slot>
+      <input type="file"
+             @change="_onFilesSelected"
+             :multiple="multiple"/>
     </label>
-    <input type="file"
-         :id="inputID"
-         @change="_onFilesSelected"
-         :multiple="multiple"/>
   </div>
 </template>
 
@@ -27,9 +26,6 @@
 </style>
 
 <script>
-  // Input/label pairs should have unique, matching IDs.
-  const randomID = () => Math.floor(Math.random() * (9999 - 1000)) + 1000
-
   export default {
     props: {
       multiple: {
@@ -44,8 +40,7 @@
 
     data () {
       return {
-        _unmounted: false,
-        inputID: `file-input-${randomID()}`
+        _unmounted: false
       }
     },
 

--- a/src/file-input.vue
+++ b/src/file-input.vue
@@ -1,0 +1,62 @@
+<template>
+    <div class="vue-fine-uploader-file-input">
+        <label :for="inputID">
+            <slot>Upload File</slot>
+        </label>
+        <input type="file"
+               :id="inputID"
+               @change="_onFilesSelected"
+               :multiple="multiple"/>
+    </div>
+</template>
+
+<style>
+    .vue-fine-uploader-file-input {
+        display: inline-block;
+    }
+
+    .vue-fine-uploader-file-input label {
+        cursor: pointer;
+    }
+
+    .vue-fine-uploader-file-input input[type="file"] {
+        width: 1px;
+        height: 1px;
+        opacity: 0;
+    }
+</style>
+
+<script>
+    // Input/label pairs should have unique, matching IDs.
+    const randomID = () => Math.floor(Math.random() * (9999 - 1000)) + 1000;
+
+    export default {
+        props: {
+            multiple: {
+                type: Boolean,
+                default: false
+            },
+            uploader: {
+                type: Object,
+                required: true
+            }
+        },
+
+        data () {
+            return {
+                _unmounted: false,
+                inputID: `file-input-${randomID()}`
+            }
+        },
+
+        beforeDestroy () {
+            this._unmounted = true;
+        },
+
+        methods: {
+            _onFilesSelected (e) {
+                this.uploader.methods.addFiles(e.target);
+            }
+        }
+    }
+</script>

--- a/src/file-input.vue
+++ b/src/file-input.vue
@@ -1,62 +1,62 @@
 <template>
-    <div class="vue-fine-uploader-file-input">
-        <label :for="inputID">
-            <slot>Upload File</slot>
-        </label>
-        <input type="file"
-               :id="inputID"
-               @change="_onFilesSelected"
-               :multiple="multiple"/>
-    </div>
+  <div class="vue-fine-uploader-file-input">
+    <label :for="inputID">
+      <slot>Upload File</slot>
+    </label>
+    <input type="file"
+         :id="inputID"
+         @change="_onFilesSelected"
+         :multiple="multiple"/>
+  </div>
 </template>
 
 <style>
-    .vue-fine-uploader-file-input {
-        display: inline-block;
-    }
+  .vue-fine-uploader-file-input {
+    display: inline-block;
+  }
 
-    .vue-fine-uploader-file-input label {
-        cursor: pointer;
-    }
+  .vue-fine-uploader-file-input label {
+    cursor: pointer;
+  }
 
-    .vue-fine-uploader-file-input input[type="file"] {
-        width: 1px;
-        height: 1px;
-        opacity: 0;
-    }
+  .vue-fine-uploader-file-input input[type="file"] {
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+  }
 </style>
 
 <script>
-    // Input/label pairs should have unique, matching IDs.
-    const randomID = () => Math.floor(Math.random() * (9999 - 1000)) + 1000;
+  // Input/label pairs should have unique, matching IDs.
+  const randomID = () => Math.floor(Math.random() * (9999 - 1000)) + 1000
 
-    export default {
-        props: {
-            multiple: {
-                type: Boolean,
-                default: false
-            },
-            uploader: {
-                type: Object,
-                required: true
-            }
-        },
+  export default {
+    props: {
+      multiple: {
+        type: Boolean,
+        default: false
+      },
+      uploader: {
+        type: Object,
+        required: true
+      }
+    },
 
-        data () {
-            return {
-                _unmounted: false,
-                inputID: `file-input-${randomID()}`
-            }
-        },
+    data () {
+      return {
+        _unmounted: false,
+        inputID: `file-input-${randomID()}`
+      }
+    },
 
-        beforeDestroy () {
-            this._unmounted = true;
-        },
+    beforeDestroy () {
+      this._unmounted = true
+    },
 
-        methods: {
-            _onFilesSelected (e) {
-                this.uploader.methods.addFiles(e.target);
-            }
-        }
+    methods: {
+      _onFilesSelected (e) {
+        this.uploader.methods.addFiles(e.target)
+      }
     }
+  }
 </script>


### PR DESCRIPTION
Should resolve #15. Supports single and multiple inputs, and hides the ugly default `<input type="file" />` styling and instead shows a `<label>` with a `for` attribute matching the unique ID of the input tag.